### PR TITLE
Add improvements to webpack to build sass files separate from js

### DIFF
--- a/content/Assets/Scripts/index.js
+++ b/content/Assets/Scripts/index.js
@@ -2,6 +2,5 @@
  * Import main Sass file so it is compiled by webpack in to
  * CSS file that can be referenced within `Views/Layout.cshtml`.
  */
-import '../Styles/index.scss';
 
 // entry point for theme JavaScript

--- a/content/Assets/Scripts/index.js
+++ b/content/Assets/Scripts/index.js
@@ -1,6 +1,1 @@
-/**
- * Import main Sass file so it is compiled by webpack in to
- * CSS file that can be referenced within `Views/Layout.cshtml`.
- */
-
 // entry point for theme JavaScript

--- a/content/Views/Layout.cshtml
+++ b/content/Views/Layout.cshtml
@@ -12,7 +12,7 @@
         <resources type="HeadScript" />
 
         <link rel="stylesheet" href="/Moov2.OrchardCore.ThemeBoilerplate/css/style.css">
-        <script src="/Moov2.OrchardCore.ThemeBoilerplate/js/bundle.js" async></script>
+        <script src="/Moov2.OrchardCore.ThemeBoilerplate/js/scripts.js" async></script>
 
         @await RenderSectionAsync("Header", required: false)
     </head>

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -7574,6 +7574,12 @@
         }
       }
     },
+    "webpack-fix-style-only-entries": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.2.1.tgz",
+      "integrity": "sha512-3e24v2C0/gquiHTZolVHdiAJKNxDnvqPyR4x2WAjbwMC7KPdACTn8YilcqsFYjHZtbaRmqOuh6kKqPmhsG+L8w==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/content/package.json
+++ b/content/package.json
@@ -21,9 +21,9 @@
     "node-sass": "^4.11.0",
     "postcss-loader": "^3.0.0",
     "sass-loader": "^7.1.0",
-    "style-loader": "^0.23.1",
     "webpack": "^4.29.6",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.2.3",
+    "webpack-fix-style-only-entries": "^0.2.1"
   },
   "dependencies": {
     "normalize.css": "^8.0.1"

--- a/content/webpack.config.js
+++ b/content/webpack.config.js
@@ -2,10 +2,12 @@ const autoprefixer = require('autoprefixer');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 
 module.exports = {
     entry: {
-        bundle: './Assets/Scripts/index.js'
+        bundle: './Assets/Scripts/index.js',
+        styles: './Assets/Styles/index.scss'
     },
     output: {
         path: path.resolve(__dirname, 'wwwroot/js'),
@@ -23,9 +25,8 @@ module.exports = {
             {
                 test: /\.scss$/,
                 use: [
-                    'style-loader',
                     MiniCssExtractPlugin.loader,
-                    'css-loader',
+                    'css-loader?-url',
                     {
                         loader: 'postcss-loader',
                         options: {
@@ -40,6 +41,7 @@ module.exports = {
         ]
     },
     plugins: [
+        new FixStyleOnlyEntriesPlugin(),
         new CleanWebpackPlugin([
             'wwwroot/css',
             'wwwroot/js'

--- a/content/webpack.config.js
+++ b/content/webpack.config.js
@@ -6,7 +6,7 @@ const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 
 module.exports = {
     entry: {
-        bundle: './Assets/Scripts/index.js',
+        scripts: './Assets/Scripts/index.js',
         styles: './Assets/Styles/index.scss'
     },
     output: {


### PR DESCRIPTION
- Used `css-loader?-url` to not check for file path
- Used FixStyleOnlyEntriesPlugin to remove the style.js artifact
- Removed style-loader as we don’t load style using js anymore