### PR TITLE
Fix issue with CI build by calling npm install

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -5,7 +5,7 @@
     "author": "Moov2 Ltd.",
     "scripts": {
         "copy:patterns": "copyfiles -u 2 \"PatternLibrary/dist/**/*\" \"wwwroot/patterns\"",
-        "build": "npm run bundle:prod && npm run build:patterns && npm run copy:patterns",
+        "build": "npm install && npm run bundle:prod && npm run build:patterns && npm run copy:patterns",
         "build:patterns": "fractal build",
         "bundle:dev": "webpack -d",
         "bundle:prod": "webpack -p",


### PR DESCRIPTION
Fix an issue when running a CI build by adding an `npm install` call to the
front end `build` script.

Fixes #8 