### PR TITLE
Add `dist/` to content .gitignore file

### DIFF
--- a/content/.gitignore
+++ b/content/.gitignore
@@ -36,6 +36,7 @@ msbuild.wrn
 # Build artifacts
 
 wwwroot/
+dist/
 
 # Dependencies
 


### PR DESCRIPTION
Adds the `dist/` directory which is created when running a local build to the `.gitignore` file for the Theme. This means you won't accidentally commit these build artefacts to your repository.

Fixes #10 