### PR TITLE
Add theme-default to Pattern Library _preview.hbs

### DIFF
--- a/content/PatternLibrary/components/_preview.hbs
+++ b/content/PatternLibrary/components/_preview.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme-default">
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Add the `theme-default` class to the `html` for the Pattern Library `_preview.hbs` file so the theme is applied by default.