### PR TITLE
Add ability to replace the Pattern Library’s images before deployment

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -4,6 +4,7 @@
     "description": "Theme boilerplate is our starting point for building Orchard Core themes.",
     "author": "Moov2 Ltd.",
     "scripts": {
+        "replace:patterns": "replace-in-file --configFile=replace-config.js",
         "copy:patterns": "copyfiles -u 2 \"PatternLibrary/dist/**/*\" \"wwwroot/patterns\"",
         "build": "npm install && npm run bundle:prod && npm run build:patterns && npm run copy:patterns",
         "build:patterns": "fractal build",
@@ -26,13 +27,15 @@
         "copyfiles": "^2.1.0",
         "css-loader": "^2.1.1",
         "mini-css-extract-plugin": "^0.5.0",
+        "copy-webpack-plugin": "^5.0.3",
         "node-sass": "^4.11.0",
         "npm-run-all": "^4.1.5",
         "postcss-loader": "^3.0.0",
         "sass-loader": "^7.1.0",
         "webpack": "^4.29.6",
         "webpack-cli": "^3.3.0",
-        "webpack-fix-style-only-entries": "^0.2.1"
+        "webpack-fix-style-only-entries": "^0.2.1",
+        "replace-in-file": "^4.1.0"
     },
     "dependencies": {
         "normalize.css": "^8.0.1"

--- a/content/replace-config.js
+++ b/content/replace-config.js
@@ -1,0 +1,9 @@
+﻿module.exports = {
+    from: [
+        /\/content\//g
+    ],
+    to: [
+        "/Moov2.OrchardCore.ThemeBoilerplate/content/"
+    ],
+    files: ["./PatternLibrary/dist/**/**/*.html", "./PatternLibrary/dist/**/**/*.css"]
+};

--- a/content/webpack.config.js
+++ b/content/webpack.config.js
@@ -3,6 +3,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
     entry: {
@@ -54,5 +55,15 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: '../css/style.css',
         }),
+        new CopyPlugin([
+            {
+                from: path.join(process.cwd(), 'Assets/Content'),
+                to: path.join(process.cwd(), 'wwwroot/content'),
+            },
+            {
+                from: path.join(process.cwd(), 'Assets/Fonts'),
+                to: path.join(process.cwd(), 'wwwroot/fonts'),
+            }
+        ]),
     ],
 };


### PR DESCRIPTION
This make PL images to work on the remote server. Also added webpack plugin to copy the contents from assets folder to wwwroot