### PR TITLE
Update npm dependencies via `npm audit fix`

### DIFF
--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -1052,9 +1052,9 @@
       }
     },
     "@frctl/mandelbrot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@frctl/mandelbrot/-/mandelbrot-1.2.0.tgz",
-      "integrity": "sha1-gBFkqO/rU1PnTmGjJt7PEAeuYh0=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@frctl/mandelbrot/-/mandelbrot-1.2.1.tgz",
+      "integrity": "sha512-SC4sGCNG7hwGMdEHJhOHy6R24STyDaAY2tM7AZQNat46LhPRUg77qrC6tvcO7YRKnKOyHas3QvJhx8WdXwhv1Q==",
       "dev": true,
       "requires": {
         "@frctl/fractal": "^1.1.0-alpha.0",
@@ -5362,9 +5362,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10069,13 +10069,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/content/package.json
+++ b/content/package.json
@@ -19,23 +19,23 @@
         "@babel/core": "^7.4.0",
         "@babel/preset-env": "^7.4.2",
         "@frctl/fractal": "^1.1.7",
-        "@frctl/mandelbrot": "^1.2.0",
+        "@frctl/mandelbrot": "^1.2.1",
         "autoprefixer": "^9.5.0",
         "babel-loader": "^8.0.5",
         "clean-webpack-plugin": "^2.0.1",
         "concurrently": "^4.1.0",
+        "copy-webpack-plugin": "^5.0.3",
         "copyfiles": "^2.1.0",
         "css-loader": "^2.1.1",
         "mini-css-extract-plugin": "^0.5.0",
-        "copy-webpack-plugin": "^5.0.3",
         "node-sass": "^4.11.0",
         "npm-run-all": "^4.1.5",
         "postcss-loader": "^3.0.0",
+        "replace-in-file": "^4.1.0",
         "sass-loader": "^7.1.0",
         "webpack": "^4.29.6",
         "webpack-cli": "^3.3.0",
-        "webpack-fix-style-only-entries": "^0.2.1",
-        "replace-in-file": "^4.1.0"
+        "webpack-fix-style-only-entries": "^0.2.1"
     },
     "dependencies": {
         "normalize.css": "^8.0.1"


### PR DESCRIPTION
Prompted by GitHub was showing a few security alerts for npm packages.